### PR TITLE
[fixed] exception where children are null or number

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -21,7 +21,7 @@ var isInteractive = (tagName, props) => {
 var hasChildTextNode = (props, children) => {
   var hasText = false;
   React.Children.forEach(children, (child) => {
-    if (hasText)
+    if (hasText || (child === null) || (typeof child === 'number'))
       return;
     else if (typeof child === 'string')
       hasText = true;


### PR DESCRIPTION
I tried to write a test for this, but I failed. Sorry!
The issue comes from using react-a11y with react-widgets's multi select box, which in some part of its tree has children that look like this: 
![screen shot 2015-02-09 at 7 49 18 pm](https://cloud.githubusercontent.com/assets/33324/6103154/d5866f68-b094-11e4-9754-d7768164353e.png)

This patch solves it, at least enough so I can continue using using it.