### PR TITLE
[added] Option to show trace on warn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist
+node_modules

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,19 +18,32 @@ var assertAccessibility = (tagName, props, children, log) => {
   }
 };
 
-var error = (passed, msg) => {
+var error = (passed, msg, options) => {
   if (!passed)
     throw new Error(msg);
 };
 
-var warn = (passed, msg) => {
-  if (!passed)
+var warn = (passed, msg, options) => {
+  if (!passed) {
     console.warn(msg);
+
+    if (options.showTrace) {
+      console.trace();
+    }
+  }
 };
+
+var getLogger = (options) => {
+  var log = options && options.throw ? error : warn;
+
+  return (passed, msg) => {
+    log(passed, msg, options);
+  };
+}
 
 module.exports = (options) => {
   var _createElement = React.createElement;
-  var log = options && options.throw ? error : warn;
+  var log = getLogger(options);
   React.createElement = function (type, _props, ...children) {
     if (typeof type === 'string') {
       var props = _props || {};


### PR DESCRIPTION
Using this in a pre-existing application it can be difficult to tell
where each of the warnings come from. This adds an option to show the
stack trace along with the warning without needing to throw an error.

Optional suggestion based on issue #4.