### PR TITLE
add option to display element's props with warn/error message

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,19 +18,31 @@ var assertAccessibility = (tagName, props, children, log) => {
   }
 };
 
-var error = (passed, msg, props) => {
+var error = (passed, msg, props, options) => {
+  var errMsg = options && options.showProps ? msg + " - Element's props:" + JSON.stringify(props) : msg;
   if (!passed)
-    throw new Error(msg + ' - props: ' + JSON.stringify(props));
+    throw new Error(errMsg);
 };
 
-var warn = (passed, msg, props) => {
+var warn = (passed, msg, props, options) => {
+  var warnMsg = options && options.showProps ? msg + " - Element's props:" + JSON.stringify(props) : msg;
   if (!passed)
-    console.warn(msg + ' - props: ' + JSON.stringify(props));
+    console.warn(warnMsg);
 };
+
+// borrowed from https://github.com/rackt/react-a11y/pull/9/files#diff-6d186b954a58d5bb740f73d84fe39073R36
+var getLogger = (options) => {
+  var log = options && options.throw ? error : warn;
+
+  return (passed, msg, props) => {
+    log(passed, msg, props, options);
+  };
+}
+
 
 module.exports = (options) => {
   var _createElement = React.createElement;
-  var log = options && options.throw ? error : warn;
+  var log = getLogger(options);
   React.createElement = function (type, _props, ...children) {
     if (typeof type === 'string') {
       var props = _props || {};

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,25 +7,25 @@ var assertAccessibility = (tagName, props, children, log) => {
   var tagTests = assertions.tags[tagName];
   if (tagTests)
     for (key in tagTests)
-      log(tagTests[key].test(tagName, props, children), tagTests[key].msg);
+      log(tagTests[key].test(tagName, props, children), tagTests[key].msg, props);
 
   var propTests;
   for (var propName in props) {
     propTests = assertions.props[propName];
     if (propTests)
       for (key in propTests)
-        log(propTests[key].test(tagName, props, children), propTests[key].msg);
+        log(propTests[key].test(tagName, props, children), propTests[key].msg, props);
   }
 };
 
-var error = (passed, msg) => {
+var error = (passed, msg, props) => {
   if (!passed)
-    throw new Error(msg);
+    throw new Error(msg + ' - props: ' + JSON.stringify(props));
 };
 
-var warn = (passed, msg) => {
+var warn = (passed, msg, props) => {
   if (!passed)
-    console.warn(msg);
+    console.warn(msg + ' - props: ' + JSON.stringify(props));
 };
 
 module.exports = (options) => {


### PR DESCRIPTION
similar to #9 but adds option to display element's props with warning/error message rather than logging full console.trace().  In my app, this is more straightforward and helpful than the full stack trace.

I'd be happy to combine this option with @mtscout6's option for stack trace from #9 