### PR TITLE
Mark all failing tags with an ID and include it in the message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist
+node_modules/

--- a/lib/__tests__/index-test.js
+++ b/lib/__tests__/index-test.js
@@ -1,3 +1,4 @@
+var React = require('react');
 var assert = require('assert');
 require('../index')();
 var assertions = require('../assertions');

--- a/lib/__tests__/index-test.js
+++ b/lib/__tests__/index-test.js
@@ -1,4 +1,3 @@
-var React = require('react');
 var assert = require('assert');
 require('../index')();
 var assertions = require('../assertions');
@@ -8,7 +7,7 @@ var k = () => {};
 var captureWarnings = (fn) => {
   var _warn = console.warn;
   var msgs = {};
-  console.warn = (msg) => msgs[msg] = true;
+  console.warn = (id, msg) => msgs[msg] = true;
   fn();
   console.warn = _warn;
   return msgs;
@@ -77,7 +76,7 @@ describe('props', () => {
           <div onClick={k}><img src="#" alt="Foo"/></div>;
         });
       });
-      
+
       it('warns if there is an image with an empty alt attribute', () => {
         expectWarning(assertions.props.onClick.NO_LABEL.msg, () => {
           <div onClick={k}><img src="#" alt=""/></div>;

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,8 +33,8 @@ module.exports = (options) => {
   var _createElement = React.createElement;
   var log = options && options.throw ? error : warn;
   React.createElement = function (type, _props, ...children) {
+    var props = _props || {};
     if (typeof type === 'string') {
-      var props = _props || {};
       var failures = assertAccessibility(type, props, children);
       if (failures.length) {
         // Generate an id if one doesn't exist
@@ -44,6 +44,7 @@ module.exports = (options) => {
           log(props.id, failures[i]);
       }
     }
-    return _createElement.apply(this, arguments);
+    // make sure props with the id is passed down, even if no props were passed in.
+    return _createElement.apply(this, [type, props].concat(children));
   };
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,42 +1,49 @@
 var React = require('react');
 var assertions = require('./assertions');
 
-var assertAccessibility = (tagName, props, children, log) => {
+var assertAccessibility = (tagName, props, children) => {
   var key;
+  var failures = [];
 
-  var tagTests = assertions.tags[tagName];
-  if (tagTests)
-    for (key in tagTests)
-      log(tagTests[key].test(tagName, props, children), tagTests[key].msg);
+  var tagTests = assertions.tags[tagName] || [];
+  for (key in tagTests)
+    if (tagTests[key] && !tagTests[key].test(tagName, props, children))
+      failures.push(tagTests[key].msg);
 
   var propTests;
   for (var propName in props) {
-    propTests = assertions.props[propName];
-    if (propTests)
-      for (key in propTests)
-        log(propTests[key].test(tagName, props, children), propTests[key].msg);
+    propTests = assertions.props[propName] || [];
+    for (key in propTests)
+      if (propTests[key] && !propTests[key].test(tagName, props, children))
+        failures.push(propTests[key].msg);
   }
+  return failures;
 };
 
-var error = (passed, msg) => {
-  if (!passed)
-    throw new Error(msg);
+var error = (id, msg) => {
+  throw new Error('#' + id + ": " + msg);
 };
 
-var warn = (passed, msg) => {
-  if (!passed)
-    console.warn(msg);
+var warn = (id, msg) => {
+  console.warn('#' + id, msg);
 };
 
+var nextId = 0;
 module.exports = (options) => {
   var _createElement = React.createElement;
   var log = options && options.throw ? error : warn;
   React.createElement = function (type, _props, ...children) {
     if (typeof type === 'string') {
       var props = _props || {};
-      assertAccessibility(type, props, children, log);
+      var failures = assertAccessibility(type, props, children);
+      if (failures.length) {
+        // Generate an id if one doesn't exist
+        props.id = (props.id || 'a11y-' + nextId++);
+
+        for (var i = 0; i < failures.length; i++)
+          log(props.id, failures[i]);
+      }
     }
     return _createElement.apply(this, arguments);
   };
 };
-


### PR DESCRIPTION
This PR restructures assertAccessibility so that when an element fails it can add a unique `id` (if one doesn't already exist) and logs it in the message.

     #a11y-0 You have an anchor with `href="#"` and no `role` DOM property. Add `role="button"` or better yet, use a `<button/>`.

`document.getElementById('a11y-0')` will show me the element that is failing. Then with `Reveal in Elements Panel` (Chrome's terminology) you can track down where it is.

Closes #11 
Closes #9
This is a better solution as it marks all of your elements so you can find them. No need to guess based on a stack or logging the props.