### PR TITLE
[fixed] Button role didn't allow onKeyDown

### DIFF
--- a/lib/__tests__/index-test.js
+++ b/lib/__tests__/index-test.js
@@ -77,7 +77,7 @@ describe('props', () => {
           <div onClick={k}><img src="#" alt="Foo"/></div>;
         });
       });
-      
+
       it('warns if there is an image with an empty alt attribute', () => {
         expectWarning(assertions.props.onClick.NO_LABEL.msg, () => {
           <div onClick={k}><img src="#" alt=""/></div>;
@@ -87,13 +87,13 @@ describe('props', () => {
 
     describe('when role="button"', () => {
       it('requires onKeyUp', () => {
-        expectWarning(assertions.props.onClick.BUTTON_ROLE_NO_KEYUP.msg, () => {
+        expectWarning(assertions.props.onClick.BUTTON_ROLE_SPACE.msg, () => {
           <span onClick={k} role="button"/>;
         });
       });
 
       it('requires onKeyDown', () => {
-        expectWarning(assertions.props.onClick.BUTTON_ROLE_NO_KEYDOWN.msg, () => {
+        expectWarning(assertions.props.onClick.BUTTON_ROLE_ENTER.msg, () => {
           <span onClick={k} role="button"/>;
         });
       });

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -77,11 +77,10 @@ exports.props = {
       }
     },
 
-    // I don't know that it matters if you use onKeyUp or onKeyDown.
     BUTTON_ROLE_ENTER: {
-      msg: 'You have `role="button"` but did not define an `onKeyDown` or `onKeyUp` handler. Add it, and have the "Enter" key do the same thing as an `onClick` handler.',
+      msg: 'You have `role="button"` but did not define an `onKeyDown` handler. Add it, and have the "Enter" key do the same thing as an `onClick` handler.',
       test (tagName, props, children) {
-        return !(props.role === 'button' && !(props.onKeyUp || props.onKeyDown));
+        return !(props.role === 'button' && props.onKeyDown);
       }
     }
 

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -68,17 +68,20 @@ exports.props = {
       }
     },
 
-    BUTTON_ROLE_NO_KEYUP: {
-      msg: 'You have `role="button"` but did not define an `onKeyUp` handler. Add it, and have the "Space" key do the same thing as an `onClick` handler.',
+    // onKeyUp is too late to cancel space's default behavior of scrolling the
+    // page.
+    BUTTON_ROLE_SPACE: {
+      msg: 'You have `role="button"` but did not define an `onKeyDown` handler. Add it, and have the "Space" key do the same thing as an `onClick` handler.',
       test (tagName, props, children) {
-        return !(props.role === 'button' && !props.onKeyUp);
+        return !(props.role === 'button' && !props.onKeyDown);
       }
     },
 
-    BUTTON_ROLE_NO_KEYDOWN: {
-      msg: 'You have `role="button"` but did not define an `onKeyDown` handler. Add it, and have the "Enter" key do the same thing as an `onClick` handler.',
+    // I don't know that it matters if you use onKeyUp or onKeyDown.
+    BUTTON_ROLE_ENTER: {
+      msg: 'You have `role="button"` but did not define an `onKeyDown` or `onKeyUp` handler. Add it, and have the "Enter" key do the same thing as an `onClick` handler.',
       test (tagName, props, children) {
-        return !(props.role === 'button' && !props.onKeyUp);
+        return !(props.role === 'button' && !(props.onKeyUp || props.onKeyDown));
       }
     }
 


### PR DESCRIPTION
onKeyUp is too late to prevent space from scrolling the browser, so it
should be onKeyDown.

While I was doing this I clarified the `BUTTON_ROLE_*` rule names and set
`BUTTON_ROLE_ENTER` to account for `onKeyUp` or `onKeyDown`