### PR TITLE
Drop React from peerDependency and rely on passing it in.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ getting warnings in the console as your app renders.
 
 ```js
 var a11y = require('react-a11y');
-if (ENV === 'development') a11y();
+if (ENV === 'development') a11y(React);
 ```
 
 You probably don't want to call it if you're in production, and better
@@ -32,6 +32,5 @@ yet, alias the module to nothing with webpack in production.
 If you want it to throw errors instead of just warnings:
 
 ```
-a11y({throw: true});
+a11y(React, {throw: true});
 ```
-

--- a/lib/__tests__/index-test.js
+++ b/lib/__tests__/index-test.js
@@ -1,6 +1,6 @@
 var React = require('react');
 var assert = require('assert');
-require('../index')();
+require('../index')(React);
 var assertions = require('../assertions');
 
 var k = () => {};

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1,4 +1,8 @@
-var React = require('react');
+var React;
+
+exports.setReact = function(R) {
+  React = R;
+};
 
 var INTERACTIVE = {
   'button': true,

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,3 @@
-var React = require('react');
 var assertions = require('./assertions');
 
 var assertAccessibility = (tagName, props, children) => {
@@ -30,7 +29,12 @@ var warn = (id, msg) => {
 };
 
 var nextId = 0;
-module.exports = (options) => {
+module.exports = (React, options) => {
+  if (!React && !React.createElement) {
+    throw new Error('Missing parameter: React');
+  }
+  assertions.setReact(React);
+
   var _createElement = React.createElement;
   var log = options && options.throw ? error : warn;
   React.createElement = function (type, _props, ...children) {

--- a/package.json
+++ b/package.json
@@ -33,12 +33,9 @@
     "karma-sourcemap-loader": "^0.3.2",
     "karma-webpack": "^1.3.1",
     "mocha": "^2.0.1",
-    "react": "0.12.x",
+    "react": "^0.12 || ^0.13",
     "rf-release": "0.4.0",
     "webpack": "^1.4.13"
-  },
-  "peerDependencies": {
-    "react": "^0.12 || ^0.13"
   },
   "tags": [
     "accessibility",


### PR DESCRIPTION
With this PR instead of `react-a11y` requiring React directly, you just pass your own React in.

```
var React = require('react');
var a11y = require('react-a11y');
if (ENV === 'development') a11y(React)
```

Closes https://github.com/rackt/react-a11y/pull/23
Closes https://github.com/rackt/react-a11y/pull/18
Fixes https://github.com/rackt/react-a11y/issues/16

Note: This and all of my other PRs are available with `npm install @asaayers/react-a11y`
[@asaayers/react-a11y](https://www.npmjs.com/package/@asaayers/react-a11y)