### PR TITLE
Use Babel for prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
   "bugs": "https://github.com/rackt/react-a11y/issues",
   "scripts": {
     "test": "jsxhint . && karma start --single-run",
-    "prepublish": "6to5 -d dist lib"
+    "prepublish": "babel -d dist lib"
   },
   "authors": [
-    "Ryan Florence"
+    "Ryan Florence",
+    "Todd Kloots",
+    "Angus Croll"
   ],
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Forgot to update the republish script to use Babel over 6to5