### PR TITLE
Elements with a role of presentation should not require a label

### DIFF
--- a/lib/__tests__/index-test.js
+++ b/lib/__tests__/index-test.js
@@ -194,6 +194,12 @@ describe('labels', () => {
     });
   });
 
+  it('does not warn when the ARIA role is presentation', () => {
+    doNotExpectWarning(assertions.render.NO_LABEL.msg, () => {
+      <span role="presentation" />;
+    });
+  });
+
   it('does not warn if the element is not interactive', () => {
     doNotExpectWarning(assertions.render.NO_LABEL.msg, () => {
       <div />;

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -180,11 +180,16 @@ exports.render = {
   NO_LABEL: {
     msg: 'You have an unlabled element or control. Add `aria-label` or `aria-labelled-by` attribute, or put some text in the element.',
     test (tagName, props, children, failureCB) {
-      if (!(isInteractive(tagName, props) || props.role))
+      var labelRequired = (
+          isInteractive(tagName, props) ||
+          props.role && props.role != 'presentation'
+        );
+
+      if (!labelRequired)
         return;
 
       var failed = !(
-        (isInteractive(tagName, props) || props.role) &&
+        labelRequired &&
         (
           props['aria-label'] ||
           props['aria-labelled-by'] ||


### PR DESCRIPTION
[fixed] issue where elements with the presentation role required a label. resolves #50