### PR TITLE
[added] "picture" to the list of redundant words in img[alt]

### DIFF
--- a/lib/__tests__/index-test.js
+++ b/lib/__tests__/index-test.js
@@ -177,6 +177,12 @@ describe('tags', () => {
         <img src="cat.gif" alt="image of a cat"/>;
       });
     });
+
+    it('dissallows the word "picture" in the alt attribute', () => {
+      expectWarning(assertions.tags.img.REDUNDANT_ALT.msg, () => {
+        <img src="cat.gif" alt="picture of a cat"/>;
+      });
+    });
   });
 
   describe('a', () => {

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -213,12 +213,12 @@ exports.tags = {
 
     REDUNDANT_ALT: {
       // TODO: have some way to set localization strings to match against
-      msg: 'Screen-readers already announce `img` tags as an image, you don\'t need to use the word "image" in the description',
+      msg: 'Screen-readers already announce `img` tags as an image, you don\'t need to use the word "image" or "picture" in the description',
       test (tagName, props, children) {
-        if (isHiddenFromAT(props))
+        if (isHiddenFromAT(props) || !hasAlt(props))
           return true;
 
-        return !(hasAlt(props) && props.alt.match('image'));
+        return !(props.alt.match('image') || props.alt.match('picture'));
       }
     }
   }


### PR DESCRIPTION
We modified the redundant alt rule to include a check for "picture". This is a rule we wanted for our own project and it seemed in line with the existing rule.

Please let us know if you have any questions or concerns

Thanks,
Matt and Kenny