### PR TITLE
[added] warningPrefix option

### DIFF
--- a/lib/__tests__/index-test.js
+++ b/lib/__tests__/index-test.js
@@ -637,3 +637,25 @@ describe('exclusions', () => {
     });
   });
 });
+
+describe('warningPrefix', () => {
+  var createElement = React.createElement;
+
+  let warningPrefix = 'react-a11y ERROR:';
+  before(() => {
+    a11y(React, { warningPrefix });
+  });
+
+  after(() => {
+    React.createElement = createElement;
+  });
+
+  it('adds the prefix to each warning message', () => {
+    expectWarning(warningPrefix + assertions.tags.img.MISSING_ALT.msg, () => {
+      <div>
+        <img id="foo" src="foo.jpg"/>
+        <img id="bar" src="foo.jpg"/>
+      </div>;
+    });
+  });
+});

--- a/lib/index.js
+++ b/lib/index.js
@@ -128,6 +128,7 @@ var logWarning = (component, failureInfo, options) => {
 
 var handleFailure = (options, reactEl, type, props, failureMsg) => {
   var includeSrcNode = options && !!options.includeSrcNode;
+  var warningPrefix = (options && options.warningPrefix) || '';
   var reactComponent = reactEl._owner;
 
   // If a Component instance, use the component's name,
@@ -138,7 +139,7 @@ var handleFailure = (options, reactEl, type, props, failureMsg) => {
   var failureInfo = {
     'tagName': name ,
     'id': props.id,
-    'msg': failureMsg
+    'msg': warningPrefix + failureMsg
   };
 
   var notifyOpts = {


### PR DESCRIPTION
warningPrefix allows one to specify an optional prefix to be added
to the failure message.

This allows us to filter out just the react-a11y errors from our console log.

Thanks,
Matt and Caroline