### PR TITLE
Children fix

### DIFF
--- a/lib/__tests__/index-test.js
+++ b/lib/__tests__/index-test.js
@@ -706,3 +706,31 @@ describe('warningPrefix', () => {
     });
   });
 });
+
+describe('testing children', () => {
+  var createElement = React.createElement;
+
+  before(() => {
+    a11y(React, { exclude: ['REDUNDANT_ALT'] });
+  });
+
+  after(() => {
+    React.createElement = createElement;
+  });
+
+  describe('when children is passed down in props', () => {
+    it('calls each test with the children', () => {
+      doNotExpectWarning(assertions.render.NO_LABEL.msg, () => {
+        React.createElement('a', {href: 'google.com', children: 'Google'});
+      });
+    });
+  });
+
+  describe('when children is passed down separately from props', () => {
+    it('calls each test with the children', () => {
+      doNotExpectWarning(assertions.render.NO_LABEL.msg, () => {
+        React.createElement('a', {href: 'google.com'}, 'Google');
+      });
+    });
+  });
+});

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -226,7 +226,7 @@ exports.tags = {
 
 exports.render = {
   NO_LABEL: {
-    msg: 'You have an unlabeled element or control. Add `aria-label` or `aria-labelled-by` attribute, or put some text in the element.',
+    msg: 'You have an unlabeled element or control. Add `aria-label` or `aria-labelledby` attribute, or put some text in the element.',
     test (tagName, props, children, failureCB) {
       if (isHiddenFromAT(props) || presentationRoles.has(props.role))
         return;

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -226,7 +226,7 @@ exports.tags = {
 
 exports.render = {
   NO_LABEL: {
-    msg: 'You have an unlabled element or control. Add `aria-label` or `aria-labelledby` attribute, or put some text in the element.',
+    msg: 'You have an unlabeled element or control. Add `aria-label` or `aria-labelled-by` attribute, or put some text in the element.',
     test (tagName, props, children, failureCB) {
       if (isHiddenFromAT(props) || presentationRoles.has(props.role))
         return;

--- a/lib/index.js
+++ b/lib/index.js
@@ -177,9 +177,12 @@ var reactA11y = (React, options) => {
     var props = _props || {};
     options = options || {};
 
+    var childrenForTest;
+
     if (children.length === 0) {
-      children = props.children;
-      delete props.children;
+      childrenForTest = props.children || [];
+    } else {
+      childrenForTest = children;
     }
 
     props.id = createId(props);
@@ -187,7 +190,7 @@ var reactA11y = (React, options) => {
     var failureCB = handleFailure.bind(undefined, options, reactEl);
 
     if (typeof type === 'string')
-      runTests(type, props, children, options, failureCB);
+      runTests(type, props, childrenForTest, options, failureCB);
 
     return reactEl;
   };

--- a/lib/index.js
+++ b/lib/index.js
@@ -177,6 +177,11 @@ var reactA11y = (React, options) => {
     var props = _props || {};
     options = options || {};
 
+    if (children.length === 0) {
+      children = props.children;
+      delete props.children;
+    }
+
     props.id = createId(props);
     var reactEl = _createElement.apply(this, [type, props].concat(children));
     var failureCB = handleFailure.bind(undefined, options, reactEl);


### PR DESCRIPTION
We were having an issue with the way children was being passed into tests. We're using react-bootstrap, which creates some links the following way:

```js
React.createElement('a', {href: 'some-href', children: 'stuff'})
```

This was giving us 'no label' errors when it should have been fine. This is because the code previously expected that `children` would be passed down as the 3rd+ argument of React.createElement.