### PR TITLE
[fixed] correctly accounting for aria-labelledby (resolves #87)

### DIFF
--- a/lib/__tests__/index-test.js
+++ b/lib/__tests__/index-test.js
@@ -314,9 +314,9 @@ describe('labels', () => {
     });
   });
 
-  it('does not warn if there is an aria-labelled-by', () => {
+  it('does not warn if there is an aria-labelledby', () => {
     doNotExpectWarning(assertions.render.NO_LABEL.msg, () => {
-      <button aria-labelled-by="foo"/>;
+      <button aria-labelledby="foo"/>;
     });
   });
 

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -226,7 +226,7 @@ exports.tags = {
 
 exports.render = {
   NO_LABEL: {
-    msg: 'You have an unlabled element or control. Add `aria-label` or `aria-labelled-by` attribute, or put some text in the element.',
+    msg: 'You have an unlabled element or control. Add `aria-label` or `aria-labelledby` attribute, or put some text in the element.',
     test (tagName, props, children, failureCB) {
       if (isHiddenFromAT(props) || presentationRoles.has(props.role))
         return;
@@ -241,7 +241,7 @@ exports.render = {
 
       var failed = !(
         props['aria-label'] ||
-        props['aria-labelled-by'] ||
+        props['aria-labelledby'] ||
         (tagName === 'img' && props.alt) ||
         hasChildTextNode(props, children, failureCB)
       );


### PR DESCRIPTION
Correctly accounts for use of the aria-labelledby attribute.