### PR TITLE
React 0.14 Compatibility: Create new props object instead of mutating existing one

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -185,12 +185,12 @@ var reactA11y = (React, options) => {
       childrenForTest = children;
     }
 
-    props.id = createId(props);
-    var reactEl = _createElement.apply(this, [type, props].concat(children));
+    var newProps = Object.assign({}, props, {id: createId(props)});
+    var reactEl = _createElement.apply(this, [type, newProps].concat(children));
     var failureCB = handleFailure.bind(undefined, options, reactEl);
 
     if (typeof type === 'string')
-      runTests(type, props, childrenForTest, options, failureCB);
+      runTests(type, newProps, childrenForTest, options, failureCB);
 
     return reactEl;
   };


### PR DESCRIPTION
In React 0.14, props are frozen. Because of this, we have to create a new props object to pass react-a11y ids along.

Long term, it would be nice (and would solve a lot of issues) if react-a11y didn't generate IDs at all. Until then, this will keep it running smoothly in React 0.14.